### PR TITLE
Fix/invalid protocol buffer exception on init

### DIFF
--- a/OpenScienceJournal/app/build.gradle
+++ b/OpenScienceJournal/app/build.gradle
@@ -9,8 +9,8 @@ android {
         applicationId "cc.arduino.sciencejournal"
         minSdkVersion 19
         targetSdkVersion 29
-        versionCode 9
-        versionName "1.3.3"
+        versionCode 10
+        versionName "1.3.4"
         multiDexEnabled true
         vectorDrawables.useSupportLibrary = true
     }

--- a/OpenScienceJournal/whistlepunk_library/build.gradle
+++ b/OpenScienceJournal/whistlepunk_library/build.gradle
@@ -21,8 +21,8 @@ android {
     defaultConfig {
         minSdkVersion 19
         targetSdkVersion 29
-        versionCode 9
-        versionName "1.3.3"
+        versionCode 10
+        versionName "1.3.4"
         vectorDrawables.useSupportLibrary = true
     }
 

--- a/OpenScienceJournal/whistlepunk_library/src/main/java/com/google/android/apps/forscience/whistlepunk/gdrivesync/GDriveShared.java
+++ b/OpenScienceJournal/whistlepunk_library/src/main/java/com/google/android/apps/forscience/whistlepunk/gdrivesync/GDriveShared.java
@@ -1,16 +1,23 @@
 package com.google.android.apps.forscience.whistlepunk.gdrivesync;
 
+import android.app.Activity;
 import android.content.Context;
+import android.content.Intent;
 import android.content.SharedPreferences;
 import android.util.Log;
 
 import androidx.security.crypto.EncryptedSharedPreferences;
 import androidx.security.crypto.MasterKey;
 
+import com.google.android.apps.forscience.whistlepunk.MainActivity;
+
 import java.io.File;
 import java.io.IOException;
 import java.security.GeneralSecurityException;
 import java.security.KeyStore;
+import java.security.KeyStoreException;
+import java.security.NoSuchAlgorithmException;
+import java.security.cert.CertificateException;
 
 public class GDriveShared {
     private static final String LOG_TAG = "GDriveShared";
@@ -61,37 +68,51 @@ public class GDriveShared {
         return mAccount;
     }
 
-    private static SharedPreferences getBrandNewSharedPreferences(Context context) {
-        MasterKey masterKey = null;
+    private static Boolean getKeystoreResetState(final Context context) {
+        SharedPreferences prefs = context.getSharedPreferences(UNENCRYPTED_SHARED_PREFS_FILENAME, Context.MODE_PRIVATE);
+        return prefs.getBoolean(KEY_KEYSTORE_RESET, false);
+    }
+    private static void setKeystoreResetState(final Context context, Boolean state) {
+        SharedPreferences prefs = context.getSharedPreferences(UNENCRYPTED_SHARED_PREFS_FILENAME, Context.MODE_PRIVATE);
+        prefs.edit().putBoolean(KEY_KEYSTORE_RESET, state).apply();
+    }
 
+    private static void resetKeystoreAndRestart(final Context context) {
+        // delete shared preferences file
+        File sharedPrefsFile = new File(context.getFilesDir().getParent() + "/shared_prefs/" + SHARED_PREFS_FILENAME + ".xml");
+        if (sharedPrefsFile.exists()) {
+            Boolean deleted = sharedPrefsFile.delete();
+            Log.i(LOG_TAG, String.format("Shared prefs file \"%s\" deleted: %s", sharedPrefsFile.getAbsolutePath(), deleted));
+        } else {
+            Log.i(LOG_TAG, String.format("Shared prefs file \"%s\" non-existent", sharedPrefsFile.getAbsolutePath()));
+        }
+
+        // delete master key
         try {
-            File sharedPrefsFile = new File(context.getFilesDir().getParent() + "/shared_prefs/" + SHARED_PREFS_FILENAME + ".xml");
-            boolean deleted = sharedPrefsFile.delete();
-
-            Log.d(LOG_TAG, String.format("Shared prefs file deleted: %s", deleted));
-
-            // delete MasterKey
             KeyStore keyStore = KeyStore.getInstance("AndroidKeyStore");
             keyStore.load(null);
             keyStore.deleteEntry(MasterKey.DEFAULT_MASTER_KEY_ALIAS);
 
-            // build MasterKey
-            masterKey = new MasterKey.Builder(context, MasterKey.DEFAULT_MASTER_KEY_ALIAS)
-                    .setKeyScheme(MasterKey.KeyScheme.AES256_GCM)
-                    .build();
-
-            // create shared preferences
-            return EncryptedSharedPreferences.create(
-                    context,
-                    SHARED_PREFS_FILENAME,
-                    masterKey,
-                    EncryptedSharedPreferences.PrefKeyEncryptionScheme.AES256_SIV,
-                    EncryptedSharedPreferences.PrefValueEncryptionScheme.AES256_GCM
-            );
-        } catch (GeneralSecurityException | IOException e) {
-            Log.e(LOG_TAG, "Unable to retrieve encrypted shared preferences", e);
-            throw new RuntimeException("Unable to retrieve encrypted shared preferences", e);
+            Log.i(LOG_TAG, "Master key deleted");
+        } catch (KeyStoreException | CertificateException | NoSuchAlgorithmException | IOException e) {
+            Log.i(LOG_TAG, "Unable to delete master key");
+            throw new RuntimeException("Unable to delete master key", e);
         }
+
+        // save on (non-encrypted) shared preferences the reset state to avoid loops
+        setKeystoreResetState(context, true);
+        Log.i(LOG_TAG, "Set keystore reset state to TRUE.");
+
+        // restart app
+        Intent intent = new Intent(context, MainActivity.class);
+        intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
+        Log.i(LOG_TAG, "Restarting application...");
+        context.startActivity(intent);
+        if (context instanceof Activity) {
+            ((Activity) context).finish();
+        }
+
+        Runtime.getRuntime().exit(0);
     }
 
     private static SharedPreferences getSharedPreferences(final Context context) {
@@ -103,20 +124,37 @@ public class GDriveShared {
                     .build();
 
             // get or create shared preferences
-            return EncryptedSharedPreferences.create(
+            SharedPreferences prefs = EncryptedSharedPreferences.create(
                     context,
                     SHARED_PREFS_FILENAME,
                     masterKey,
                     EncryptedSharedPreferences.PrefKeyEncryptionScheme.AES256_SIV,
                     EncryptedSharedPreferences.PrefValueEncryptionScheme.AES256_GCM
             );
+
+            // set keystore reset to false to enable future resets
+            setKeystoreResetState(context, false);
+            Log.i(LOG_TAG, "Set keystore reset state to FALSE.");
+
+            return prefs;
         } catch (GeneralSecurityException | IOException e) {
-            Log.e(LOG_TAG, "Unable to retrieve encrypted shared preferences, regenerating master key.", e);
-            return getBrandNewSharedPreferences(context);
+            Boolean keystoreReset = getKeystoreResetState(context);
+            if (keystoreReset) {
+                // a keystore reset just occurred, interrupt execution to avoid loops
+                throw new RuntimeException("Unable to retrieve encrypted shared preferences", e);
+            } else {
+                Log.i(LOG_TAG, "Unable to retrieve encrypted shared preferences, regenerating master key.", e);
+                resetKeystoreAndRestart(context);
+            }
+
+            return null;
         }
     }
 
+
     private static final String SHARED_PREFS_FILENAME = "GoogleDriveSync";
+    private static final String UNENCRYPTED_SHARED_PREFS_FILENAME = "ArduinoSharedPreferencesSafe";
+    private static final String KEY_KEYSTORE_RESET = "keystore_reset";
     private static final String KEY_ACCOUNT_ID = "account_id";
     private static final String KEY_EMAIL = "email";
     private static final String KEY_TOKEN = "token";


### PR DESCRIPTION
In case of a faulty MasterKey the app was not able to decrypt the EncryptedSharedPreferences file and crash. As solution we delete the file and the MasterKey, generating a new one after an application restart.